### PR TITLE
Use usernames as tags

### DIFF
--- a/game_state.py
+++ b/game_state.py
@@ -25,7 +25,7 @@ class GameState:
         tags = []
 
         for tag in self._tanks:
-            if self._tanks[tag].sid == sid:
+            if self._tanks[tag]._js_data['sid'] == sid:
                 tags.append(tag)
 
         return tags

--- a/game_state.py
+++ b/game_state.py
@@ -21,6 +21,15 @@ class GameState:
     def get_tank(self, tag):
         return self._tanks[tag]
 
+    def on_disconnect(self, sid):
+        tags = []
+
+        for tag in self._tanks:
+            if self._tanks[tag].sid == sid:
+                tags.append(tag)
+
+        return tags
+
     # Game start and stop stuff
     def tanks_still_alive(self):
         return [tag for tag in self._tanks if self._tanks[tag]._js_data['isAlive']]

--- a/game_state.py
+++ b/game_state.py
@@ -7,17 +7,17 @@ class GameState:
     def add_tank(self, x, y, r, colour, name, sid):
         self._tanks[sid] = Tank(x, y, r, colour, name, sid)
 
-    def update_tank(self, sid, tank_json):
-        self._tanks[sid].update_from_json(tank_json)
+    def update_tank(self, tag, tank_json):
+        self._tanks[tag].update_from_json(tank_json)
 
-    def explode_tank(self, sid):
-        self._tanks[sid].explode()
+    def explode_tank(self, tag):
+        self._tanks[tag].explode()
 
-    def delete_tank(self, sid):
-        del self._tanks[sid]
+    def delete_tank(self, tag):
+        del self._tanks[tag]
 
-    def get_tank(self, sid):
-        return self._tanks[sid]
+    def get_tank(self, tag):
+        return self._tanks[tag]
 
     def tanks_json(self):
-        return {k: self._tanks[k].to_json() for k in self._tanks}
+        return {tag: self._tanks[tag].to_json() for tag in self._tanks}

--- a/game_state.py
+++ b/game_state.py
@@ -21,14 +21,26 @@ class GameState:
     def get_tank(self, tag):
         return self._tanks[tag]
 
+    def has_tank(self, tag):
+        return tag in self._tanks
+
     def on_disconnect(self, sid):
-        tags = []
+        kicked_tags = []
 
+        # Search to find out which tanks are attached to the sid that has disconnected.
         for tag in self._tanks:
-            if self._tanks[tag]._js_data['sid'] == sid:
-                tags.append(tag)
+            tank = self._tanks[tag]
 
-        return tags
+            if tank._sid == sid:
+                # The tank has been disconnected, so subtract its login count by one
+                tank.login_count -= 1
+
+                if tank.login_count == 0:
+                    kicked_tags.append(tag)
+
+                    del self._tanks[tag]
+
+        return kicked_tags
 
     # Game start and stop stuff
     def tanks_still_alive(self):

--- a/game_state.py
+++ b/game_state.py
@@ -3,7 +3,9 @@ from tank import Tank
 class GameState:
     def __init__(self):
         self._tanks = {}
+        self._scoreboard = {}
 
+    # Tank editing functions
     def add_tank(self, x, y, r, colour, name, sid):
         self._tanks[name] = Tank(x, y, r, colour, name, sid)
 
@@ -19,5 +21,16 @@ class GameState:
     def get_tank(self, tag):
         return self._tanks[tag]
 
+    # Game start and stop stuff
+    def tanks_still_alive(self):
+        return [tag for tag in self._tanks if self._tanks[tag]._js_data['isAlive']]
+
+    def start_new_game(self):
+        print("Starting new game")
+
+    def finish_game(self, winner):
+        print(f"{winner or 'No-one'} won.")
+
+    # JSON exporting stuff
     def tanks_json(self):
         return {tag: self._tanks[tag].to_json() for tag in self._tanks}

--- a/game_state.py
+++ b/game_state.py
@@ -5,7 +5,7 @@ class GameState:
         self._tanks = {}
 
     def add_tank(self, x, y, r, colour, name, sid):
-        self._tanks[sid] = Tank(x, y, r, colour, name, sid)
+        self._tanks[name] = Tank(x, y, r, colour, name, sid)
 
     def update_tank(self, tag, tank_json):
         self._tanks[tag].update_from_json(tank_json)

--- a/server.py
+++ b/server.py
@@ -122,4 +122,4 @@ if __name__ == '__main__':
     broadcast_thread = threading.Thread(target=broadcast_loop)
     broadcast_thread.start()
 
-    socketio.run(app, debug=False)
+    socketio.run(app, host='0.0.0.0', debug=False)

--- a/server.py
+++ b/server.py
@@ -98,7 +98,7 @@ def on_tank_explode(data):
 
     tankLock.acquire()
     try:
-        game_state.explode_tank(data['tag'])
+        game_state.explode_tank(data['tankTag'])
 
         num_tanks_alive = len(game_state.tanks_still_alive())
         if num_tanks_alive == 1:

--- a/server.py
+++ b/server.py
@@ -75,9 +75,9 @@ def on_user_leave_2():
 
     tankLock.acquire()
     try:
-        game_state.delete_tank(request.sid)
+        tags = game_state.on_disconnect(request.sid)
 
-        socketio.emit('s_on_user_leave', {'id': request.sid})
+        socketio.emit('s_on_user_leave', tags)
     finally:
         tankLock.release()
 

--- a/server.py
+++ b/server.py
@@ -94,11 +94,11 @@ def on_tank_move(tank_data):
 
 @socketio.on('c_on_tank_explode')
 def on_tank_explode(data):
-    socketio.emit('s_on_tank_explode', {'tank': request.sid, 'projectile': data['projectile']})
+    socketio.emit('s_on_tank_explode', data);
 
     tankLock.acquire()
     try:
-        game_state.explode_tank(request.sid)
+        game_state.explode_tank(data['tag'])
 
         num_tanks_alive = len(game_state.tanks_still_alive())
         if num_tanks_alive == 1:

--- a/server.py
+++ b/server.py
@@ -84,10 +84,10 @@ def on_user_leave_2():
 
 @socketio.on('c_on_tank_move')
 def on_tank_move(tank_data):
+    game_state.update_tank(tank_data['tag'], tank_data['newState'])
+
     tankLock.acquire()
     try:
-        game_state.update_tank(tank_data['tag'], tank_data['newState'])
-
         socketio.emit('s_on_tank_move', tank_data)
     finally:
         tankLock.release()

--- a/server.py
+++ b/server.py
@@ -83,12 +83,12 @@ def on_user_leave_2():
 
 
 @socketio.on('c_on_tank_move')
-def on_tank_move(updated_tank):
+def on_tank_move(tank_data):
     tankLock.acquire()
     try:
-        game_state.update_tank(request.sid, updated_tank)
+        game_state.update_tank(tank_data['tag'], tank_data['newState'])
 
-        socketio.emit('s_on_tank_move', game_state.tanks_json())
+        socketio.emit('s_on_tank_move', tank_data)
     finally:
         tankLock.release()
 

--- a/server.py
+++ b/server.py
@@ -99,6 +99,12 @@ def on_tank_explode(data, method=['GET', 'POST']):
     tankLock.acquire()
     try:
         game_state.explode_tank(request.sid)
+
+        num_tanks_alive = len(game_state.tanks_still_alive())
+        if num_tanks_alive == 1:
+            print("One tank remaining")
+        elif num_tanks_alive == 0:
+            print("No tanks remaining")
     finally:
         tankLock.release()
 

--- a/server.py
+++ b/server.py
@@ -55,14 +55,19 @@ def on_new_user_arrive(json):
 
     tankLock.acquire()
     try:
-        game_state.add_tank(
-            random.random(),
-            random.random(),
-            random.random() * 8,
-            json['colour'],
-            json['name'],
-            request.sid
-        )
+        username = json['name']
+
+        if game_state.has_tank(username):
+            game_state.get_tank(username).login_count += 1
+        else:
+            game_state.add_tank(
+                random.random(),
+                random.random(),
+                random.random() * 8,
+                json['colour'],
+                username,
+                request.sid
+            )
 
         socketio.emit('s_on_new_user_arrive', game_state.tanks_json())
     finally:

--- a/static/tanks.js
+++ b/static/tanks.js
@@ -115,15 +115,16 @@ function onLoad() {
         }
     });
     socket.on('s_on_tank_explode', function(data) {
-        var id = data.tank;
+        var tank = tanks[data.tankTag];
 
-        tanks[id].isAlive = false;
-
-        if (id != socket.id) {
-            tanks[id].destructionTime = Date.now();
+        // Start animation if this tank's explosion is new to us
+        if (tank.isAlive) {
+            tank.destructionTime = Date.now();
         }
 
-        delete projectiles[data.projectile];
+        tank.isAlive = false;
+
+        delete projectiles[data.projectileTag];
     });
 
     // Set up callbacks

--- a/static/tanks.js
+++ b/static/tanks.js
@@ -84,9 +84,11 @@ function onLoad() {
         tanks = state;
         serverTanks = state;
     });
-    socket.on('s_on_user_leave', function(id) {
-        delete tanks[id.id];
-        delete serverTanks[id.id];
+    socket.on('s_on_user_leave', function(tags) {
+        for (var i = 0; i < tags.length; i++) {
+            delete tanks[tags[i]];
+            delete serverTanks[tag[i]];
+        }
     });
     socket.on('s_broadcast', function(state) { updateServerTankState(state); });
     socket.on('s_on_tank_move', function(state) { updateServerTankState(state); });

--- a/static/tanks.js
+++ b/static/tanks.js
@@ -91,7 +91,14 @@ function onLoad() {
         }
     });
     socket.on('s_broadcast', function(state) { updateServerTankState(state); });
-    socket.on('s_on_tank_move', function(state) { updateServerTankState(state); });
+    socket.on('s_on_tank_move', function(tankData) {
+        // Copy the fields of the new state into the right tank, since this only sends the updated
+        // state, rather than the entire gamestate.  This is one of the rare cases where using TCP
+        // is actually an advantage.
+        for (field in tankData.newState) {
+            serverTanks[tankData.tag][field] = tankData.newState[field];
+        }
+    });
     socket.on('s_spawn_projectile', function(newProj) {
         // Check if the projectile is new and isn't one of ours
         if (!(newProj.id in projectiles)) {

--- a/tank.py
+++ b/tank.py
@@ -12,6 +12,7 @@ class Tank:
         }
         self._sid = sid
         self._username = username
+        self.login_count = 1
 
     def explode(self):
         self._js_data['isAlive'] = False


### PR DESCRIPTION
Internal change that fixes a lot of bugs about duplicating tanks when refreshing the client page.